### PR TITLE
Fix: Resolve mouse click handler scope isolation issue

### DIFF
--- a/lua/mpv/actions.lua
+++ b/lua/mpv/actions.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-M.left_mouse = function(state, conf)
+M.left_mouse = function(state, conf, win_id)
     local mouse = vim.fn.getmousepos()
-    if M.win ~= mouse.winid then return end
+    if win_id ~= mouse.winid then return end
 
     local pause = math.floor(conf.width/2)
     local prev = math.floor(conf.width/4)

--- a/lua/mpv/init.lua
+++ b/lua/mpv/init.lua
@@ -160,7 +160,7 @@ M.toggle_player = function()
     map('<', '<')
     map('<LeftMouse>', '',
         function()
-            actions.left_mouse()
+            actions.left_mouse(state, conf, M.win)
             refresh_screen()
         end
     )


### PR DESCRIPTION
Thank you for creating such a great nvim plugin.
I always make good use of it.

### Summary

This PR fixes a bug in the mouse event handler where mouse clicks on player
controls (play/pause, previous, next) were silently failing. The issue was caused by
a Lua scope isolation problem where the handler function attempted to reference an
undefined variable from another module's scope.

### Problem Description

The `left_mouse()` function in `lua/mpv/actions.lua` referenced `M.win` directly,
but this variable only exists in `lua/mpv/init.lua`'s module scope. In Lua, each
module maintains its own local scope, so cross-module variable access requires
explicit parameter passing.

Additionally, the caller was missing the required parameters:

```lua
-- Before
M.left_mouse = function(state, conf)
    if M.win ~= mouse.winid then return end  -- M.win is undefined

-- Called with no arguments
actions.left_mouse()  -- state and conf are nil
```

This resulted in the function receiving nil values and having no access to M.win,
causing all mouse click handlers to fail silently.

### Solution

Pass the required values as explicit parameters:

```lua
-- After
M.left_mouse = function(state, conf, win_id)
    if win_id ~= mouse.winid then return end

-- Called with parameters
actions.left_mouse(state, conf, M.win)
```

